### PR TITLE
[Fixpack1]Add timestamp in image query

### DIFF
--- a/doc/source/parameters.yaml
+++ b/doc/source/parameters.yaml
@@ -1063,3 +1063,10 @@ size_output:
   in: body
   required: true
   type: string
+last_access_time:
+  description: |
+    the time stamp of last access time of this image
+    the seconds count after 1970 and is generated from python ``time`` module.
+  in: body
+  required: true
+  type: float

--- a/doc/source/restapi.rst
+++ b/doc/source/restapi.rst
@@ -1297,6 +1297,7 @@ Get the list of image info in image repository.
   - image_size_in_bytes: physical_disk_size_image
   - type: image_type
   - comments: image_comments
+  - last_access_time: last_access_time
 
 * Response sample:
 

--- a/zvmsdk/returncode.py
+++ b/zvmsdk/returncode.py
@@ -215,6 +215,8 @@ errors = {
                21: "Image Export error: Failed to copy image file to remote "
                    "host with reason: %(msg)s",
                22: "Export image to local file system failed: %(err)s",
+               23: "Image file of %(img)s does not exist, "
+                   "so failed to get its timestamp.",
                },
               "Operation on Image failed"
               ],

--- a/zvmsdk/smtclient.py
+++ b/zvmsdk/smtclient.py
@@ -2102,8 +2102,41 @@ class SMTClient(object):
         image_path = self._get_image_path_by_name(image_name)
         self._pathutils.clean_temp_folder(image_path)
 
-    def image_query(self, imagename=None):
-        return self._ImageDbOperator.image_query_record(imagename)
+    def _get_image_last_access_time(self, image_name, raise_exception=True):
+        """Get the last access time of the image."""
+        image_file = os.path.join(self._get_image_path_by_name(image_name),
+                                  CONF.zvm.user_root_vdev)
+        if not os.path.exists(image_file):
+            if raise_exception:
+                msg = 'Failed to get time stamp of image:%s' % image_name
+                LOG.error(msg)
+                raise exception.SDKImageOperationError(rs=23, img=image_name)
+            else:
+                # An invalid timestamp
+                return -1
+        atime = os.path.getatime(image_file)
+        return atime
+
+    def image_query(self, image_name=None):
+        image_info = self._ImageDbOperator.image_query_record(image_name)
+        if not image_info:
+            # because database maybe None, so return nothing here
+            return []
+
+        # if image_name is not None, means there is only one record
+        if image_name:
+            last_access_time = self._get_image_last_access_time(
+                                   image_name, raise_exception=False)
+            image_info[0]['last_access_time'] = last_access_time
+        else:
+            for item in image_info:
+                image_name = item['imagename']
+                # set raise_exception to false because one failed
+                # may stop processing all the items in the list
+                last_access_time = self._get_image_last_access_time(
+                                       image_name, raise_exception=False)
+                item['last_access_time'] = last_access_time
+        return image_info
 
     def image_get_root_disk_size(self, image_name):
         """Return the root disk units of the specified image

--- a/zvmsdk/tests/unit/test_smtclient.py
+++ b/zvmsdk/tests/unit/test_smtclient.py
@@ -1302,11 +1302,54 @@ class SDKSMTClientTestCases(base.SDKTestCase):
                           self._smtclient.image_import,
                           image_name, url, image_meta)
 
-    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
-    def test_image_query(self, image_query):
+    @mock.patch.object(smtclient.SMTClient, '_get_image_path_by_name')
+    def test_get_image_access_time_image_not_exist(self, image_path):
         image_name = "testimage"
-        self._smtclient.image_query(image_name)
+        image_path.return_value = '/tmp/notexistpath/'
+        self.assertRaises(exception.SDKImageOperationError,
+                          self._smtclient._get_image_last_access_time,
+                          image_name)
+
+    @mock.patch.object(smtclient.SMTClient, '_get_image_last_access_time')
+    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
+    def test_image_query(self, image_query, access_time):
+        image_name = "testimage"
+        fake_access_time = 1581910539.3330014
+        access_time.return_value = fake_access_time
+        image_query.return_value = [{'imagename': 'testimage'}]
+        image_info = self._smtclient.image_query(image_name)
         image_query.assert_called_once_with(image_name)
+        self.assertEqual(image_info[0]['last_access_time'],
+                         fake_access_time)
+
+    @mock.patch.object(smtclient.SMTClient, '_get_image_last_access_time')
+    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
+    def test_image_query_image_not_exist(self, image_query, access_time):
+        image_name = "testimage"
+        fake_access_time = 1581910539.3330014
+        access_time.return_value = fake_access_time
+        image_query.return_value = None
+        image_info = self._smtclient.image_query(image_name)
+        self.assertEqual(image_info, [])
+
+    @mock.patch.object(smtclient.SMTClient, '_get_image_last_access_time')
+    @mock.patch.object(database.ImageDbOperator, 'image_query_record')
+    def test_image_query_none_imagename(self, image_query, access_time):
+        image_name = None
+        fake_access_time = 1581910539.3330014
+        image_query.return_value = [{u'image_size_in_bytes': u'719045489',
+                                     u'last_access_time': 1581910539.3330014,
+                                     u'disk_size_units': u'3339:CYL',
+                                     u'md5sum': u'157e2a2c3be1d49ef6e69324',
+                                     u'comments': None,
+                                     u'imagename': u'testimage',
+                                     u'imageosdistro': u'rhel7',
+                                     u'type': u'rootonly'}]
+        access_time.return_value = fake_access_time
+        image_info = self._smtclient.image_query(image_name)
+        image_query.assert_called_once_with(image_name)
+        self.assertEqual(image_info[0]['last_access_time'],
+                         fake_access_time)
 
     @mock.patch.object(database.ImageDbOperator, 'image_delete_record')
     @mock.patch.object(smtclient.SMTClient, '_delete_image_file')

--- a/zvmsdk/tests/unit/test_vmops.py
+++ b/zvmsdk/tests/unit/test_vmops.py
@@ -145,21 +145,28 @@ class SDKVMOpsTestCase(base.SDKTestCase):
         self.assertRaises(exception.ZVMVirtualMachineNotExist,
                           self.vmops.get_info, 'fakeid')
 
+    @mock.patch("zvmsdk.smtclient.SMTClient._get_image_last_access_time")
+    @mock.patch("zvmsdk.database.ImageDbOperator.image_query_record")
     @mock.patch("zvmsdk.smtclient.SMTClient.guest_deploy")
-    def test_guest_deploy(self, deploy_image_to_vm):
+    def test_guest_deploy(self, deploy_image_to_vm,
+                          img_query, get_atime):
+        get_atime.return_value = 1581910539.3330014
+        img_query.return_value = [{'imageosdistro': 'rhel6.7'}]
         self.vmops.guest_deploy('fakevm', 'fakeimg',
                                 '/test/transport.tgz')
         deploy_image_to_vm.assert_called_with('fakevm', 'fakeimg',
                                               '/test/transport.tgz', None,
                                               None)
 
+    @mock.patch("zvmsdk.smtclient.SMTClient._get_image_last_access_time")
     @mock.patch('zvmsdk.vmops.VMOps.set_hostname')
     @mock.patch("zvmsdk.database.ImageDbOperator.image_query_record")
     @mock.patch("zvmsdk.smtclient.SMTClient.guest_deploy")
     def test_guest_deploy_sethostname(self, deploy_image_to_vm, img_query,
-                                      set_hostname):
+                                      set_hostname, get_atime):
         fake_hostname = 'fakehost'
         img_query.return_value = [{'imageosdistro': 'rhel6.7'}]
+        get_atime.return_value = 1581910539.3330014
         self.vmops.guest_deploy('fakevm', 'fakeimg',
                                 hostname=fake_hostname)
         deploy_image_to_vm.assert_called_with('fakevm', 'fakeimg', None, None,


### PR DESCRIPTION
add timestamp info to support manage_image_cache API in nova ZVM driver

Signed-off-by: SharpRazor <bjcb@cn.ibm.com>