### PR TITLE
add 7.1 support for Query_API_Functional_Level

### DIFF
--- a/zthin-parts/zthin/src/rcdescriptions.c
+++ b/zthin-parts/zthin/src/rcdescriptions.c
@@ -137,6 +137,9 @@ void printSmapiDescriptionAndLogError(const char * APIname, int rc, int rs, stru
     } else if (rc == 0 && rs == 640) {
         sprintf(errMsg, "The API functional level is z/VM V6.4\n");
         logMSG = false;
+    } else if (rc == 0 && rs == 710) {
+        sprintf(errMsg, "The API functional level is z/VM V7.1\n");
+        logMSG = false;
     } else if (rc == 4 && rs == 4) {
         sprintf(errMsg, "Request does not exist\n");
     } else if (rc == 4 && rs == 5) {

--- a/zthin-parts/zthin/src/smcliQuery.c
+++ b/zthin-parts/zthin/src/smcliQuery.c
@@ -331,6 +331,7 @@ int queryAPIFunctionalLevel(int argC, char* argV[], struct _vmApiInternalContext
                     "    For z/VM V6.2, this API will provide a return and reason code of 0/620.\n"
                     "    For z/VM V6.3, this API will provide a return and reason code of 0/630.\n"
                     "    For z/VM V6.4, this API will provide a return and reason code of 0/640.\n\n"
+                    "    For z/VM V7.1, this API will provide a return and reason code of 0/710.\n\n"
                     "  The following options are required:\n"
                     "    -T    This must match an entry in the authorization file\n");
                 printRCheaderHelp();
@@ -386,6 +387,10 @@ int queryAPIFunctionalLevel(int argC, char* argV[], struct _vmApiInternalContext
     } else if ((output->common.returnCode == 0) && ((output->common.reasonCode >= 640 || output->common.reasonCode < 650))) {
         DOES_CALLER_WANT_RC_HEADER_SMAPI_RC0_RS(vmapiContextP, output->common.returnCode, output->common.reasonCode) \
         printf("The API functional level is z/VM V6.4\n");
+    } else if ((output->common.returnCode == 0) && (output->common.reasonCode >= 710)) {
+        DOES_CALLER_WANT_RC_HEADER_SMAPI_RC0_RS(vmapiContextP, output->common.returnCode, output->common.reasonCode) \
+        printf("The API functional level is z/VM V7.1\n");
+
     } else {
         // Handle SMAPI return code and reason code
         rc = printAndLogSmapiReturnCodeReasonCodeDescription("Query_API_Functional_Level", output->common.returnCode,


### PR DESCRIPTION
Query_API_Functional_Level doesn't support z/VM 7.1 now...

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>