### PR TITLE
[1.1.1-hot-1]sles15 supports the ephemeral and swap disk

### DIFF
--- a/data/setupDisk
+++ b/data/setupDisk
@@ -527,10 +527,12 @@ function setupDisk {
     xcat_vaddr=`echo $xcat_vaddr | tr '[A-Z]' '[a-z]'`
 
     # Online the device
-    rc= onlineDevice $xcat_vaddr
-    if (( rc != 0 )); then
-      echo "$funcName (Error) fail to online the disk $xcat_vaddr"
-      return
+    # When the distro is sles15, the following /sbin/dasd_configure will online and configure device
+    if [[ $os != sles15* ]]; then
+      onlineDevice $xcat_vaddr
+      if (( $? != 0 )); then
+        echo "$funcName (Error) fail to online the disk $xcat_vaddr"
+      fi
     fi
 
     # Configure the added dasd to be persistent


### PR DESCRIPTION
Make sure the ephemeral and swap disk still exist on sles15 vm after reboot.

Signed-off-by: wgxoyun <wgxoyun@cn.ibm.com>