### PR TITLE
[1.1.1-hot-1]add command to permanently online the disk for ubuntu20

### DIFF
--- a/data/setupDisk
+++ b/data/setupDisk
@@ -542,6 +542,8 @@ function setupDisk {
       fi
     elif [[ $os == sles* ]]; then
       /sbin/dasd_configure 0.0.$xcat_vaddr 1
+    elif [[ $os == ubuntu20* ]]; then
+      chzdev -e dasd 0.0.$xcat_vaddr
     elif [[ $os == ubuntu16* ]]; then
       touch /etc/sysconfig/hardware/config-ccw-0.0.$xcat_vaddr
     else


### PR DESCRIPTION
Already reviewed in openmainframe master. @wghaojue 
@dongyanyang
https://github.ibm.com/zvc/planning/issues/2698